### PR TITLE
[codex] Fix K2 Plus homing heartbeat stalls

### DIFF
--- a/scripts/menu/K2PLUS/tools_menu_K2PLUS.sh
+++ b/scripts/menu/K2PLUS/tools_menu_K2PLUS.sh
@@ -27,6 +27,8 @@ function tools_menu_ui_k2plus() {
   hr
   menu_option '13' 'Reset' 'factory settings'
   hr
+  menu_option '14' 'Fix' 'Stepper too far in past on G28'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -103,6 +105,8 @@ function tools_menu_k2plus() {
         run "restore_previous_firmware" "tools_menu_ui_k2plus";;
       13)
         run "reset_factory_settings" "tools_menu_ui_k2plus";;
+      14)
+        run "fix_k2plus_homing_cfs_heartbeat" "tools_menu_ui_k2plus";;
       B|b)
         clear; main_menu; break;;
       Q|q)

--- a/scripts/menu/functions.sh
+++ b/scripts/menu/functions.sh
@@ -180,19 +180,31 @@ function restart_nginx() {
 
 function start_klipper() {
   set +e
-  /etc/init.d/S55klipper_service start
+  if [ -x /etc/init.d/S55klipper_service ]; then
+    /etc/init.d/S55klipper_service start
+  else
+    /etc/init.d/klipper start
+  fi
   set -e
 }
 
 function stop_klipper() {
   set +e
-  /etc/init.d/S55klipper_service stop
+  if [ -x /etc/init.d/S55klipper_service ]; then
+    /etc/init.d/S55klipper_service stop
+  else
+    /etc/init.d/klipper stop
+  fi
   set -e
 }
 
 function restart_klipper() {
   set +e
-  /etc/init.d/S55klipper_service restart
+  if [ -x /etc/init.d/S55klipper_service ]; then
+    /etc/init.d/S55klipper_service restart
+  else
+    /etc/init.d/klipper restart
+  fi
   set -e
 }
 

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -36,6 +36,17 @@ function printing_gcode_from_folder_message(){
   bottom_line
 }
 
+function fix_k2plus_homing_cfs_heartbeat_message(){
+  top_line
+  title 'Fix K2 Plus homing shutdown' "${yellow}"
+  inner_line
+  hr
+  echo -e " │ ${cyan}This pauses CFS heartbeat traffic while K2 Plus sensorless   ${white}│"
+  echo -e " │ ${cyan}homing is running to reduce MCU timing stalls.               ${white}│"
+  hr
+  bottom_line
+}
+
 function enable_camera_settings_message(){
   top_line
   title 'Enable camera settings in Moonraker' "${yellow}"
@@ -165,6 +176,197 @@ function printing_gcode_from_folder(){
         restart_klipper
         ok_msg "Fix has been applied successfully!"
         return;;
+      N|n)
+        error_msg "Installation canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}
+
+function _k2plus_has_disable_heartbeat_wait(){
+  awk '
+    /^\[homing_override\][[:space:]]*$/ { inside=1; next }
+    /^\[/ && inside { inside=0 }
+    inside && /^[[:space:]]*BOX_DISABLE_HEART_PROCESS[[:space:]]+TNN=T1A[[:space:]]*$/ {
+      wait_for_g4=1
+      next
+    }
+    wait_for_g4 && /^[[:space:]]*G4[[:space:]]+P[0-9]+[[:space:]]*$/ {
+      found=1
+      wait_for_g4=0
+    }
+    wait_for_g4 && $0 !~ /^[[:space:]]*$/ {
+      wait_for_g4=0
+    }
+    END { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+function _k2plus_has_homing_y_settle(){
+  awk '
+    /^\[homing_override\][[:space:]]*$/ { inside=1; next }
+    /^\[/ && inside { inside=0 }
+    inside && /^[[:space:]]*_HOME_Y[[:space:]]*$/ {
+      after_home_y=1
+      has_m400=0
+      has_g4=0
+      next
+    }
+    after_home_y && /^[[:space:]]*M400[[:space:]]*$/ { has_m400=1 }
+    after_home_y && /^[[:space:]]*G4[[:space:]]+P[0-9]+[[:space:]]*$/ { has_g4=1 }
+    after_home_y && index($0, "{% endif %}") {
+      if (has_m400 && has_g4) {
+        found=1
+      }
+      after_home_y=0
+    }
+    END { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+function _patch_k2plus_homing_cfs_heartbeat(){
+  local sensorless_file="$1"
+
+  if [ ! -f "$sensorless_file" ]; then
+    error_msg "sensorless.cfg not found!"
+    return 1
+  fi
+
+  if ! grep -q "^\[homing_override\]" "$sensorless_file"; then
+    error_msg "homing_override section not found in sensorless.cfg!"
+    return 1
+  fi
+
+  local add_disable=0
+  local add_disable_wait=0
+  local add_enable=0
+  local add_y_settle=0
+
+  if ! grep -q "BOX_DISABLE_HEART_PROCESS TNN=T1A" "$sensorless_file"; then
+    add_disable=1
+  elif ! _k2plus_has_disable_heartbeat_wait "$sensorless_file"; then
+    add_disable_wait=1
+  fi
+
+  if ! grep -q "BOX_ENABLE_HEART_PROCESS TNN=T1A" "$sensorless_file"; then
+    add_enable=1
+  fi
+
+  if ! _k2plus_has_homing_y_settle "$sensorless_file"; then
+    add_y_settle=1
+  fi
+
+  if [ "$add_disable" -eq 0 ] && [ "$add_disable_wait" -eq 0 ] && [ "$add_enable" -eq 0 ] && [ "$add_y_settle" -eq 0 ]; then
+    ok_msg "Fix is already applied!"
+    return 2
+  fi
+
+  local backup_file="${sensorless_file}.bak_$(date +%Y%m%d_%H%M%S)"
+  local tmp_file="${sensorless_file}.tmp.$$"
+
+  echo -e "Info: Backing up sensorless.cfg to ${backup_file}..."
+  cp "$sensorless_file" "$backup_file"
+
+  echo -e "Info: Applying K2 Plus homing CFS heartbeat fix..."
+  if ! awk \
+    -v add_disable="$add_disable" \
+    -v add_disable_wait="$add_disable_wait" \
+    -v add_enable="$add_enable" \
+    -v add_y_settle="$add_y_settle" '
+      function leading_ws(line) {
+        match(line, /^[ \t]*/)
+        return substr(line, RSTART, RLENGTH)
+      }
+      /^\[homing_override\][[:space:]]*$/ {
+        inside=1
+        print
+        next
+      }
+      /^\[/ && inside { inside=0 }
+      inside && add_disable && /^[[:space:]]*gcode:[[:space:]]*$/ {
+        print
+        print "  BOX_DISABLE_HEART_PROCESS TNN=T1A"
+        print "  G4 P500"
+        add_disable=0
+        add_disable_wait=0
+        next
+      }
+      inside && add_disable_wait && /^[[:space:]]*BOX_DISABLE_HEART_PROCESS[[:space:]]+TNN=T1A[[:space:]]*$/ {
+        print
+        print leading_ws($0) "G4 P500"
+        add_disable_wait=0
+        next
+      }
+      inside && add_y_settle && /^[[:space:]]*_HOME_Y[[:space:]]*$/ {
+        print
+        indent=leading_ws($0)
+        print indent "M400"
+        print indent "G4 P1000"
+        add_y_settle=0
+        next
+      }
+      inside && add_enable && index($0, "{% set acc = printer.toolhead.max_accel %}") {
+        print "  BOX_ENABLE_HEART_PROCESS TNN=T1A"
+        add_enable=0
+      }
+      { print }
+      END {
+        if (add_disable || add_disable_wait || add_enable || add_y_settle) {
+          exit 3
+        }
+      }
+    ' "$sensorless_file" > "$tmp_file"; then
+    rm -f "$tmp_file"
+    error_msg "Failed to patch sensorless.cfg!"
+    return 1
+  fi
+
+  if ! grep -q "BOX_DISABLE_HEART_PROCESS TNN=T1A" "$tmp_file" || \
+     ! grep -q "BOX_ENABLE_HEART_PROCESS TNN=T1A" "$tmp_file" || \
+     ! _k2plus_has_homing_y_settle "$tmp_file"; then
+    rm -f "$tmp_file"
+    error_msg "Patched sensorless.cfg did not pass validation!"
+    return 1
+  fi
+
+  mv "$tmp_file" "$sensorless_file"
+  return 0
+}
+
+function fix_k2plus_homing_cfs_heartbeat(){
+  fix_k2plus_homing_cfs_heartbeat_message
+  local yn
+  while true; do
+    read -p "${white} Do you want to apply fix for ${green}K2 Plus homing shutdown ${white}? (${yellow}y${white}/${yellow}n${white}): ${yellow}" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        if [ "$model" != "K2PLUS" ]; then
+          error_msg "This fix is only supported on K2 Plus!"
+          return
+        fi
+
+        local patch_result=0
+        if _patch_k2plus_homing_cfs_heartbeat "$KLIPPER_CONFIG_FOLDER/sensorless.cfg"; then
+          patch_result=0
+        else
+          patch_result=$?
+        fi
+
+        case "$patch_result" in
+          0)
+            echo -e "Info: Restarting Klipper service..."
+            restart_klipper
+            ok_msg "Fix has been applied successfully!"
+            return;;
+          2)
+            return;;
+          *)
+            error_msg "Fix was not applied!"
+            return;;
+        esac;;
       N|n)
         error_msg "Installation canceled!"
         return;;

--- a/tests/k2plus_homing_cfs_heartbeat_test.sh
+++ b/tests/k2plus_homing_cfs_heartbeat_test.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPER_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+ok_msg() {
+  echo "OK: $*"
+}
+
+error_msg() {
+  echo "ERROR: $*" >&2
+}
+
+assert_equals() {
+  expected="$1"
+  actual="$2"
+  message="$3"
+
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL: $message. Expected '$expected', got '$actual'." >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  needle="$1"
+  file="$2"
+
+  if ! grep -q "$needle" "$file"; then
+    echo "FAIL: '$needle' was not found in $file." >&2
+    exit 1
+  fi
+}
+
+count_matches() {
+  pattern="$1"
+  file="$2"
+  grep -c "$pattern" "$file"
+}
+
+. "$HELPER_ROOT/scripts/tools.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+sensorless_file="$tmp_dir/sensorless.cfg"
+cat > "$sensorless_file" <<'CFG'
+[gcode_macro _HOME_Y]
+gcode:
+  G28 Y
+
+[homing_override]
+axes: xyz
+gcode:
+  MOTOR_STALL_MODE DATA=1
+  {% if home_all or 'Y' in params %}
+    _HOME_Y
+  {% endif %}
+  MOTOR_SYS_PARAM NUM=1 DATA=1 ID=70 PARAMS=100 PARAMS_TYPE=float
+  {% set acc = printer.toolhead.max_accel %}
+  M204 S{acc}
+CFG
+
+if _patch_k2plus_homing_cfs_heartbeat "$sensorless_file"; then
+  first_rc=0
+else
+  first_rc=$?
+fi
+
+assert_equals "0" "$first_rc" "first patch run should apply changes"
+assert_contains "BOX_DISABLE_HEART_PROCESS TNN=T1A" "$sensorless_file"
+assert_contains "G4 P500" "$sensorless_file"
+assert_contains "M400" "$sensorless_file"
+assert_contains "G4 P1000" "$sensorless_file"
+assert_contains "BOX_ENABLE_HEART_PROCESS TNN=T1A" "$sensorless_file"
+assert_equals "1" "$(count_matches 'BOX_DISABLE_HEART_PROCESS TNN=T1A' "$sensorless_file")" "disable heartbeat command count"
+assert_equals "1" "$(count_matches 'BOX_ENABLE_HEART_PROCESS TNN=T1A' "$sensorless_file")" "enable heartbeat command count"
+assert_equals "1" "$(count_matches 'G4 P1000' "$sensorless_file")" "Y homing settle command count"
+
+if _patch_k2plus_homing_cfs_heartbeat "$sensorless_file"; then
+  second_rc=0
+else
+  second_rc=$?
+fi
+
+assert_equals "2" "$second_rc" "second patch run should report already applied"
+assert_equals "1" "$(count_matches 'BOX_DISABLE_HEART_PROCESS TNN=T1A' "$sensorless_file")" "disable heartbeat command should stay idempotent"
+assert_equals "1" "$(count_matches 'BOX_ENABLE_HEART_PROCESS TNN=T1A' "$sensorless_file")" "enable heartbeat command should stay idempotent"
+assert_equals "1" "$(count_matches 'G4 P1000' "$sensorless_file")" "Y homing settle command should stay idempotent"
+
+echo "k2plus_homing_cfs_heartbeat_test: OK"


### PR DESCRIPTION
## What changed

- Adds a K2 Plus helper action that patches `sensorless.cfg` to pause CFS heartbeat traffic during sensorless homing.
- Inserts `BOX_DISABLE_HEART_PROCESS TNN=T1A`, a short settle delay, and `BOX_ENABLE_HEART_PROCESS TNN=T1A` idempotently with a timestamped backup.
- Exposes the action in the K2 Plus tools menu.
- Falls back to `/etc/init.d/klipper` when `S55klipper_service` is not present.
- Adds a shell regression test for initial patching and repeated no-op behavior.

## Why

On K2 Plus, CFS/box serial traffic can overlap with G28 sensorless homing and trigger Klipper/MCU timing failures such as `Stepper too far in past` and repeated `trsync_state` timeouts. Temporarily pausing the heartbeat while homing avoids that serial contention window.

## Validation

- `sh tests/k2plus_homing_cfs_heartbeat_test.sh`
- `bash -n scripts/tools.sh scripts/menu/K2PLUS/tools_menu_K2PLUS.sh scripts/menu/functions.sh`
- Tested on a real K2 Plus over SSH: clean temporary config patches once, second run reports already applied, and the public helper function reports already applied on the live config without restarting Klipper.
